### PR TITLE
update scopemanager with currentscope

### DIFF
--- a/thread-context/build.sbt
+++ b/thread-context/build.sbt
@@ -1,7 +1,8 @@
 libraryDependencies ++= Seq(
   "com.lucidchart" % "thread-context" % "0.7",
-  "io.opentracing" % "opentracing-api" % "0.31.0",
-  "io.opentracing" % "opentracing-noop" % "0.31.0"
+  "io.opentracing" % "opentracing-api" % "0.32.0",
+  "io.opentracing" % "opentracing-noop" % "0.32.0",
+  "io.opentracing" % "opentracing-util" % "0.32.0"
 )
 
 name := s"opentracing-${name.value}"

--- a/thread-context/src/main/java/io/opentracing/threadcontext/ContextSpan.java
+++ b/thread-context/src/main/java/io/opentracing/threadcontext/ContextSpan.java
@@ -4,22 +4,35 @@ import com.github.threadcontext.Context;
 import com.github.threadcontext.MutableContextSupplier;
 import com.github.threadcontext.ThreadLocalContextSupplier;
 import com.github.threadcontext.control.TryFinallyContext;
+import io.opentracing.Scope;
 import io.opentracing.noop.NoopSpan;
 import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 
 public class ContextSpan {
 
     public static final ContextSpan DEFAULT = new ContextSpan(Context.DEFAULT);
 
     private final ThreadLocal<Span> span;
+    // Only unclosed scopes are persisted here.
+    private final ThreadLocal<Scope> scope;
+    private final Tracer tracer;
 
     public ContextSpan(MutableContextSupplier contextSupplier) {
+        this(contextSupplier, GlobalTracer.get());
+    }
+
+    public ContextSpan(MutableContextSupplier contextSupplier, Tracer customTracer) {
+        tracer = customTracer;
         span = new ThreadLocal<Span>() {
             protected Span initialValue() {
                 return NoopSpan.INSTANCE;
             }
         };
+        scope = new ThreadLocal<Scope>();
         contextSupplier.suppliers.add(new ThreadLocalContextSupplier<>(span));
+        contextSupplier.suppliers.add(new ThreadLocalContextSupplier<>(scope));
     }
 
     public Span get() {
@@ -29,8 +42,21 @@ public class ContextSpan {
     public Context set(Span span) {
         return new TryFinallyContext(() -> {
             Span oldValue = this.span.get();
+            Scope oldScope = this.scope.get();
+            if (oldScope != null) {
+                oldScope.close();
+                this.scope.set(null);
+            }
             this.span.set(span);
-            return () -> this.span.set(oldValue);
+            Scope scope = this.tracer.activateSpan(span);
+            return () -> {
+                scope.close();
+                this.span.set(oldValue);
+                if (oldValue != NoopSpan.INSTANCE) {
+                    Scope newScope = this.tracer.activateSpan(oldValue);
+                    this.scope.set(newScope);
+                }
+            };
         });
     }
 


### PR DESCRIPTION
with new versions opentracing API, Scopemanager is added. The changes in the PR enable working with tracers based on the most recent versions of opentracing API.